### PR TITLE
Update connector initialization

### DIFF
--- a/plugin/Plugin.cs
+++ b/plugin/Plugin.cs
@@ -107,6 +107,15 @@ namespace MusicBeePlugin
         private PluginSettingsManager settingsManager;
         private TextBox endpointTextBox;
 
+        /// <summary>
+        /// Create the connector using the currently loaded settings.
+        /// </summary>
+        private void CreateConnector()
+        {
+            connector?.Dispose();
+            connector = new MbPiConnector(settingsManager.Settings.EndpointUrl);
+        }
+
         public PluginInfo Initialise(IntPtr apiInterfacePtr)
         {
             Assembly thisAssem = typeof(Plugin).Assembly;
@@ -121,7 +130,7 @@ namespace MusicBeePlugin
             mbApiInterface = new MusicBeeApiInterface();
             mbApiInterface.Initialise(apiInterfacePtr);
             settingsManager = new PluginSettingsManager(mbApiInterface.Setting_GetPersistentStoragePath());
-            connector = new MbPiConnector(settingsManager.Settings.EndpointUrl);
+            CreateConnector();
             // add menu item under the playing track context menu
             mbApiInterface.MB_AddMenuItem("mnuContext/Send to iPod", null, OnSendToIpod);
             about.PluginInfoVersion = PluginInfoVersion;
@@ -191,8 +200,7 @@ namespace MusicBeePlugin
 
             settingsManager.Save();
 
-            connector?.Dispose();
-            connector = new MbPiConnector(settingsManager.Settings.EndpointUrl);
+            CreateConnector();
         }
 
         // MusicBee is closing the plugin (plugin is being disabled by user or MusicBee is shutting down)


### PR DESCRIPTION
## Summary
- read endpoint URL from saved settings when creating the connector
- provide a helper method to recreate the connector after settings changes

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d97f12d488323bf6d88fb484b5e70