### PR TITLE
Add upload queue and progress events

### DIFF
--- a/PluginTests/ConnectorTests.cs
+++ b/PluginTests/ConnectorTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MusicBeePlugin;
+using Xunit;
+
+namespace PluginTests
+{
+    class StubHandler : HttpMessageHandler
+    {
+        public HttpResponseMessage Response { get; set; } = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("ok") };
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Response);
+        }
+    }
+
+    public class ConnectorTests
+    {
+        [Fact]
+        public async Task UploadFileAsync_RaisesCompletedEvent()
+        {
+            var handler = new StubHandler();
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var connector = new MbPiConnector("http://localhost");
+
+            // replace internal client via reflection for test
+            typeof(MbPiConnector).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(connector, client);
+
+            var temp = Path.GetTempFileName();
+            File.WriteAllText(temp, "data");
+
+            UploadCompletedEventArgs? args = null;
+            connector.UploadCompleted += (s, e) => args = e;
+            await connector.UploadFileAsync(temp);
+
+            Assert.NotNull(args);
+            Assert.Equal(temp, args!.FilePath);
+            Assert.Equal("ok", args.Response);
+        }
+
+        [Fact]
+        public async Task UploadFileAsync_RaisesFailedEvent()
+        {
+            var handler = new StubHandler { Response = new HttpResponseMessage(HttpStatusCode.InternalServerError) };
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var connector = new MbPiConnector("http://localhost");
+            typeof(MbPiConnector).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(connector, client);
+            var temp = Path.GetTempFileName();
+            File.WriteAllText(temp, "data");
+
+            UploadFailedEventArgs? args = null;
+            connector.UploadFailed += (s, e) => args = e;
+            await Assert.ThrowsAsync<HttpRequestException>(() => connector.UploadFileAsync(temp));
+
+            Assert.NotNull(args);
+            Assert.Equal(temp, args!.FilePath);
+        }
+    }
+}

--- a/PluginTests/QueueTests.cs
+++ b/PluginTests/QueueTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MusicBeePlugin;
+using Xunit;
+
+namespace PluginTests
+{
+    class FakeConnector : MbPiConnector
+    {
+        private readonly Queue<string> _log;
+        public FakeConnector(Queue<string> log) : base("http://localhost")
+        {
+            _log = log;
+        }
+        public override async Task<string> UploadFileAsync(string path, string category = null)
+        {
+            await Task.Yield();
+            _log.Enqueue(path);
+            UploadCompleted?.Invoke(this, new UploadCompletedEventArgs(path, "ok"));
+            return "ok";
+        }
+    }
+
+    public class QueueTests
+    {
+        [Fact]
+        public async Task ProcessesFilesSequentially()
+        {
+            var log = new Queue<string>();
+            var connector = new FakeConnector(log);
+            var queue = new FileUploadQueue(connector);
+
+            var t1 = new TaskCompletionSource<bool>();
+            var t2 = new TaskCompletionSource<bool>();
+            int count = 0;
+            queue.UploadCompleted += (s, e) =>
+            {
+                count++;
+                if (count == 1) t1.SetResult(true);
+                if (count == 2) t2.SetResult(true);
+            };
+
+            queue.Enqueue("a");
+            queue.Enqueue("b");
+
+            await Task.WhenAll(t1.Task, t2.Task);
+
+            Assert.Equal(new[] { "a", "b" }, log.ToArray());
+        }
+    }
+}

--- a/plugin/FileUploadQueue.cs
+++ b/plugin/FileUploadQueue.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MusicBeePlugin
+{
+    /// <summary>
+    /// Simple sequential upload queue for <see cref="MbPiConnector"/>.
+    /// </summary>
+    public class FileUploadQueue : IDisposable
+    {
+        private readonly MbPiConnector _connector;
+        private readonly Queue<string> _queue = new Queue<string>();
+        private bool _processing;
+
+        public event EventHandler<UploadCompletedEventArgs> UploadCompleted;
+        public event EventHandler<UploadFailedEventArgs> UploadFailed;
+
+        public FileUploadQueue(MbPiConnector connector)
+        {
+            _connector = connector ?? throw new ArgumentNullException(nameof(connector));
+            _connector.UploadCompleted += (s, e) => UploadCompleted?.Invoke(this, e);
+            _connector.UploadFailed += (s, e) => UploadFailed?.Invoke(this, e);
+        }
+
+        public void Enqueue(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentException("path is required", nameof(path));
+
+            lock (_queue)
+            {
+                _queue.Enqueue(path);
+                if (!_processing)
+                {
+                    _processing = true;
+                    _ = ProcessQueue();
+                }
+            }
+        }
+
+        private async Task ProcessQueue()
+        {
+            while (true)
+            {
+                string next;
+                lock (_queue)
+                {
+                    if (_queue.Count == 0)
+                    {
+                        _processing = false;
+                        return;
+                    }
+                    next = _queue.Dequeue();
+                }
+
+                try
+                {
+                    await _connector.UploadFileAsync(next).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // exceptions are surfaced via UploadFailed event
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _connector.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add events for upload completion and failure in `MbPiConnector`
- implement `FileUploadQueue` to process uploads sequentially
- hook queue into `Plugin` and report results to MusicBee
- add tests for connector events and queue order

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d99b29b448323ab7f8ac22ecda396