### PR TITLE
Add multi-file uploads with status messages

### DIFF
--- a/PluginTests/ContextMenuTests.cs
+++ b/PluginTests/ContextMenuTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using MusicBeePlugin;
+using Xunit;
+
+namespace PluginTests
+{
+    public class ContextMenuTests
+    {
+        [Fact]
+        public async Task SelectedFilesAreEnqueued()
+        {
+            // prepare fake connector to log uploads
+            var log = new Queue<string>();
+            var connector = new FakeConnector(log);
+            var queue = new FileUploadQueue(connector);
+            var plugin = new Plugin();
+
+            // set private fields via reflection
+            typeof(Plugin).GetField("uploadQueue", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(plugin, queue);
+
+            var api = new Plugin.MusicBeeApiInterface();
+            api.Library_QueryFilesEx = (string q, out string[] files) => { files = new[] { "a", "b" }; return true; };
+            api.NowPlaying_GetFileUrl = () => null!;
+            api.MB_SetBackgroundTaskMessage = _ => { };
+            api.MB_SendNotification = _ => { };
+
+            typeof(Plugin).GetField("mbApiInterface", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(plugin, api);
+
+            var method = typeof(Plugin).GetMethod("OnSendToIpod", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            var t1 = new TaskCompletionSource<bool>();
+            var t2 = new TaskCompletionSource<bool>();
+            int count = 0;
+            queue.UploadCompleted += (s, e) =>
+            {
+                count++;
+                if (count == 1) t1.SetResult(true);
+                if (count == 2) t2.SetResult(true);
+            };
+
+            method.Invoke(plugin, new object[] { null!, EventArgs.Empty });
+
+            await Task.WhenAll(t1.Task, t2.Task);
+
+            Assert.Equal(new[] { "a", "b" }, log.ToArray());
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ This requires a .NET SDK with Windows desktop support because the plugin targets
 ## Configuration
 
 When loaded in MusicBee the plugin exposes a settings panel where the Raspberry Pi endpoint URL can be set.
-Uploads are queued and performed sequentially; progress and errors are printed to the MusicBee trace log.
+Uploads are queued and performed sequentially. Multiple selected tracks can be sent in a single action and a status message within MusicBee shows progress.
+Errors and completion notices are logged and also shown via notifications.
 
 ## Roadmap
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,8 +25,8 @@ This roadmap outlines the steps needed to transform this template into a plugin 
 ## 4. Context Menu Integration
 
 1. Use `mbApiInterface.MB_AddMenuItem` (via `MB_AddMenuItemDelegate`) to add a **"Send to iPod"** item in the track and album context menus.
-2. When triggered, obtain the file paths of the selected tracks using the API methods in `MusicBeeInterface.cs`.
-3. Pass the paths to the connector library for upload.
+2. When triggered, obtain the file paths of the selected tracks using `Library_QueryFilesEx` ("domain=SelectedFiles") from `MusicBeeInterface.cs`.
+3. Pass the paths to the connector library for upload; multiple selections should enqueue all chosen files.
 
 ## 5. File Transfer Logic
 
@@ -36,8 +36,8 @@ This roadmap outlines the steps needed to transform this template into a plugin 
 
 ## 6. Feedback to the User
 
-1. Display a status message or progress bar in MusicBee while transfers are active.
-2. Consider using MusicBee's notification API to show success or failure messages.
+1. Display a status message or progress bar in MusicBee while transfers are active. Use `MB_SetBackgroundTaskMessage` to update progress for each file.
+2. Use MusicBee's notification API via `MB_SendNotification` to show success or failure messages in addition to logging.
 
 ## 7. Testing and Debugging
 

--- a/plugin/FileUploadQueue.cs
+++ b/plugin/FileUploadQueue.cs
@@ -13,6 +13,7 @@ namespace MusicBeePlugin
         private readonly Queue<string> _queue = new Queue<string>();
         private bool _processing;
 
+        public event EventHandler<string> UploadStarted;
         public event EventHandler<UploadCompletedEventArgs> UploadCompleted;
         public event EventHandler<UploadFailedEventArgs> UploadFailed;
 
@@ -56,6 +57,7 @@ namespace MusicBeePlugin
 
                 try
                 {
+                    UploadStarted?.Invoke(this, next);
                     await _connector.UploadFileAsync(next).ConfigureAwait(false);
                 }
                 catch


### PR DESCRIPTION
## Summary
- enqueue all selected tracks when sending to iPod
- report upload progress using background task messages and notifications
- emit event when uploads start
- document new behaviour and update roadmap
- add regression test for context menu selections

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da2ddc9088323a4e6e01a7f3cdfcd