### PR TITLE
Add API key authentication

### DIFF
--- a/PluginTests/SettingsManagerTests.cs
+++ b/PluginTests/SettingsManagerTests.cs
@@ -16,10 +16,12 @@ namespace PluginTests
             {
                 var manager = new PluginSettingsManager(tempDir);
                 manager.Settings.EndpointUrl = "http://example.com";
+                manager.Settings.ApiKey = "secret";
                 manager.Save();
 
                 var manager2 = new PluginSettingsManager(tempDir);
                 Assert.Equal("http://example.com", manager2.Settings.EndpointUrl);
+                Assert.Equal("secret", manager2.Settings.ApiKey);
             }
             finally
             {
@@ -36,6 +38,7 @@ namespace PluginTests
             {
                 var manager = new PluginSettingsManager(tempDir);
                 Assert.Equal("http://localhost:8000", manager.Settings.EndpointUrl);
+                Assert.Equal(string.Empty, manager.Settings.ApiKey);
             }
             finally
             {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This requires a .NET SDK with Windows desktop support because the plugin targets
 
 ## Configuration
 
-When loaded in MusicBee the plugin exposes a settings panel where the Raspberry Pi endpoint URL can be set.
+When loaded in MusicBee the plugin exposes a settings panel where the Raspberry Pi endpoint URL and optional API key can be set.
 Uploads are queued and performed sequentially. Multiple selected tracks can be sent in a single action and a status message within MusicBee shows progress.
 Errors and completion notices are logged and also shown via notifications.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,7 +30,7 @@ This roadmap outlines the steps needed to transform this template into a plugin 
 
 ## 5. File Transfer Logic
 
-1. Implement HTTP POST requests in `MbPiConnector` to send files to the Raspberry Pi API.
+1. Implement HTTP POST requests in `MbPiConnector` to send files to the Raspberry Pi API, including an optional API key header for authentication.
 2. Add progress reporting and error handling (e.g., via events or callbacks) so the MusicBee UI can display status.
 3. Provide a way to queue multiple tracks for transfer to avoid blocking the UI thread.
 

--- a/plugin/MbPiConnector.cs
+++ b/plugin/MbPiConnector.cs
@@ -41,18 +41,25 @@ namespace MusicBeePlugin
     public class MbPiConnector : IDisposable
     {
         private readonly HttpClient _client;
+        private readonly string _apiKey;
 
         public event EventHandler<UploadCompletedEventArgs> UploadCompleted;
         public event EventHandler<UploadFailedEventArgs> UploadFailed;
 
         /// <summary>
         /// Create a connector with the given base url, e.g. "http://pi:8000".
+        /// An optional API key will be sent with each request.
         /// </summary>
-        public MbPiConnector(string baseUrl)
+        public MbPiConnector(string baseUrl, string apiKey = null)
         {
             if (string.IsNullOrEmpty(baseUrl))
                 throw new ArgumentException("baseUrl is required", nameof(baseUrl));
             _client = new HttpClient { BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/") };
+            _apiKey = apiKey ?? string.Empty;
+            if (!string.IsNullOrEmpty(_apiKey))
+            {
+                _client.DefaultRequestHeaders.Add("X-Api-Key", _apiKey);
+            }
         }
 
         public void Dispose()

--- a/plugin/Plugin.cs
+++ b/plugin/Plugin.cs
@@ -107,6 +107,7 @@ namespace MusicBeePlugin
         private FileUploadQueue uploadQueue;
         private PluginSettingsManager settingsManager;
         private TextBox endpointTextBox;
+        private TextBox apiKeyTextBox;
         private int uploadTotal;
         private int uploadCompleted;
 
@@ -117,7 +118,8 @@ namespace MusicBeePlugin
         {
             uploadQueue?.Dispose();
             connector?.Dispose();
-            connector = new MbPiConnector(settingsManager.Settings.EndpointUrl);
+            connector = new MbPiConnector(settingsManager.Settings.EndpointUrl,
+                settingsManager.Settings.ApiKey);
             uploadQueue = new FileUploadQueue(connector);
             uploadQueue.UploadStarted += (s, path) =>
                 mbApiInterface.MB_SetBackgroundTaskMessage($"Uploading {Path.GetFileName(path)} ({uploadCompleted + 1}/{uploadTotal})");
@@ -191,7 +193,9 @@ namespace MusicBeePlugin
                 Panel configPanel = (Panel)Panel.FromHandle(panelHandle);
                 Label prompt = new Label { AutoSize = true, Location = new Point(0, 0), Text = "Endpoint URL:" };
                 endpointTextBox = new TextBox { Bounds = new Rectangle(90, 0, 200, 20), Text = settingsManager.Settings.EndpointUrl };
-                configPanel.Controls.AddRange(new Control[] { prompt, endpointTextBox });
+                Label keyLabel = new Label { AutoSize = true, Location = new Point(0, 30), Text = "API Key:" };
+                apiKeyTextBox = new TextBox { Bounds = new Rectangle(90, 30, 200, 20), Text = settingsManager.Settings.ApiKey };
+                configPanel.Controls.AddRange(new Control[] { prompt, endpointTextBox, keyLabel, apiKeyTextBox });
             }
             else
             {
@@ -201,13 +205,15 @@ namespace MusicBeePlugin
                     dlg.FormBorderStyle = FormBorderStyle.FixedDialog;
                     dlg.StartPosition = FormStartPosition.CenterParent;
                     dlg.Width = 350;
-                    dlg.Height = 120;
+                    dlg.Height = 160;
 
                     Label prompt = new Label { AutoSize = true, Location = new Point(10, 10), Text = "Endpoint URL:" };
                     endpointTextBox = new TextBox { Location = new Point(110, 8), Width = 200, Text = settingsManager.Settings.EndpointUrl };
-                    Button ok = new Button { Text = "OK", DialogResult = DialogResult.OK, Location = new Point(110, 40) };
-                    Button cancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Location = new Point(200, 40) };
-                    dlg.Controls.AddRange(new Control[] { prompt, endpointTextBox, ok, cancel });
+                    Label keyLabel = new Label { AutoSize = true, Location = new Point(10, 40), Text = "API Key:" };
+                    apiKeyTextBox = new TextBox { Location = new Point(110, 38), Width = 200, Text = settingsManager.Settings.ApiKey };
+                    Button ok = new Button { Text = "OK", DialogResult = DialogResult.OK, Location = new Point(110, 70) };
+                    Button cancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Location = new Point(200, 70) };
+                    dlg.Controls.AddRange(new Control[] { prompt, endpointTextBox, keyLabel, apiKeyTextBox, ok, cancel });
                     dlg.AcceptButton = ok;
                     dlg.CancelButton = cancel;
 
@@ -228,6 +234,8 @@ namespace MusicBeePlugin
                 settingsManager = new PluginSettingsManager(mbApiInterface.Setting_GetPersistentStoragePath());
             if (endpointTextBox != null)
                 settingsManager.Settings.EndpointUrl = endpointTextBox.Text;
+            if (apiKeyTextBox != null)
+                settingsManager.Settings.ApiKey = apiKeyTextBox.Text;
 
             settingsManager.Save();
 

--- a/plugin/PluginSettings.cs
+++ b/plugin/PluginSettings.cs
@@ -4,8 +4,8 @@ namespace MusicBeePlugin
 {
     /// <summary>
     /// Represents user configurable plugin settings.
-    /// Currently only the endpoint URL is stored but more
-    /// fields may be added in future versions.
+    /// Currently the endpoint URL and API key are stored but
+    /// more fields may be added in future versions.
     /// </summary>
     [DataContract]
     public class PluginSettings
@@ -15,5 +15,11 @@ namespace MusicBeePlugin
         /// </summary>
         [DataMember(Name = "endpointUrl")]
         public string EndpointUrl { get; set; } = "http://localhost:8000";
+
+        /// <summary>
+        /// Optional API key sent with each request.
+        /// </summary>
+        [DataMember(Name = "apiKey")]
+        public string ApiKey { get; set; } = "";
     }
 }


### PR DESCRIPTION
## Summary
- support API key in `MbPiConnector`
- persist API key in settings
- expose API key field in configuration UI
- update roadmap and readme
- add unit tests for authentication handling

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd3b2122c83238a9347eb4ab6d527