### PR TITLE
Improve upload queue to pass category

### DIFF
--- a/PluginTests/ConnectorTests.cs
+++ b/PluginTests/ConnectorTests.cs
@@ -119,5 +119,21 @@ namespace PluginTests
             Assert.True(handler.LastRequest!.Headers.Contains("X-Api-Key"));
             Assert.Equal("secret", handler.LastRequest!.Headers.GetValues("X-Api-Key").First());
         }
+
+        [Fact]
+        public async Task CategoryAppendedToUrl()
+        {
+            var handler = new StubHandler();
+            var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var connector = new MbPiConnector("http://localhost");
+            typeof(MbPiConnector).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(connector, client);
+
+            var temp = Path.GetTempFileName();
+            File.WriteAllText(temp, "data");
+            await connector.UploadFileAsync(temp, "podcast");
+
+            Assert.NotNull(handler.LastRequest);
+            Assert.EndsWith("/upload/podcast", handler.LastRequest!.RequestUri!.AbsoluteUri);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This requires a .NET SDK with Windows desktop support because the plugin targets
 
 When loaded in MusicBee the plugin exposes a settings panel where the Raspberry Pi endpoint URL and optional API key can be set.
 Uploads are queued and performed sequentially. Multiple selected tracks can be sent in a single action and a status message within MusicBee shows progress.
+The plugin maps the MusicBee **Kind** tag to API categories (music, podcast or audiobook) so files are automatically organised on the Pi.
 Errors and completion notices are logged and also shown via notifications.
 
 ## Roadmap

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,6 +59,7 @@ This roadmap outlines the steps needed to transform this template into a plugin 
 - Resume interrupted transfers.
 - Support playlists or entire libraries.
 - Add automatic syncing when new tracks are added in MusicBee.
+- Automatically categorise uploads using the track "Kind" tag.
 
 ---
 

--- a/plugin/Plugin.cs
+++ b/plugin/Plugin.cs
@@ -344,7 +344,18 @@ namespace MusicBeePlugin
                 {
                     foreach (var f in files)
                     {
-                        uploadQueue.Enqueue(f);
+                        string kind = mbApiInterface.Library_GetFileProperty(f, FilePropertyType.Kind);
+                        string category = null;
+                        if (!string.IsNullOrEmpty(kind))
+                        {
+                            if (kind.Equals("Audiobook", StringComparison.OrdinalIgnoreCase))
+                                category = "audiobook";
+                            else if (kind.Equals("Podcast", StringComparison.OrdinalIgnoreCase))
+                                category = "podcast";
+                            else
+                                category = "music";
+                        }
+                        uploadQueue.Enqueue(f, category);
                     }
                     uploadTotal += files.Length;
                     mbApiInterface.MB_SetBackgroundTaskMessage($"Queued {uploadTotal - uploadCompleted} file(s) for upload");
@@ -354,7 +365,18 @@ namespace MusicBeePlugin
                     string file = mbApiInterface.NowPlaying_GetFileUrl();
                     if (!string.IsNullOrEmpty(file))
                     {
-                        uploadQueue.Enqueue(file);
+                        string kind = mbApiInterface.NowPlaying_GetFileProperty(FilePropertyType.Kind);
+                        string category = null;
+                        if (!string.IsNullOrEmpty(kind))
+                        {
+                            if (kind.Equals("Audiobook", StringComparison.OrdinalIgnoreCase))
+                                category = "audiobook";
+                            else if (kind.Equals("Podcast", StringComparison.OrdinalIgnoreCase))
+                                category = "podcast";
+                            else
+                                category = "music";
+                        }
+                        uploadQueue.Enqueue(file, category);
                         uploadTotal++;
                         mbApiInterface.MB_SetBackgroundTaskMessage($"Queued {uploadTotal - uploadCompleted} file(s) for upload");
                     }


### PR DESCRIPTION
## Summary
- support categories in `FileUploadQueue` and accept `category` on `Enqueue`
- map MusicBee track *Kind* to category when queuing files
- add unit tests for category behavior
- document automatic category mapping in README and roadmap

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dde7c7cdc8323a9eaec1c5dfde6b5